### PR TITLE
Various fixes and improvements for recent Java and Jenkins versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
     <dependencies>
         <dependency> <!-- https://github.com/aragozin/jvm-tools/tree/master/hprof-heap -->
             <groupId>org.gridkit.jvmtool</groupId>
-            <artifactId>hprof-heap</artifactId>
-            <version>0.8.1</version>
+            <artifactId>heaplib</artifactId>
+            <version>0.2</version>
         </dependency>
     </dependencies>
     <properties>

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -19,12 +19,25 @@ public class Main {
         Heap heap = HeapFactory.createFastHeap(dump);
         System.err.println();
         System.err.print("Looking for builds thought be running according to FlowExecutionList...");
-        JavaClass felC = heap.getJavaClassByName("org.jenkinsci.plugins.workflow.flow.FlowExecutionList");
-        List<Instance> fels = felC.getInstances();
-        if (fels.size() != 1) {
-            throw new IllegalStateException("unexpected FlowExecutionList count: " + fels);
+        Instance fel = null;
+        JavaClass feldsC = heap.getJavaClassByName("org.jenkinsci.plugins.workflow.flow.FlowExecutionList$DefaultStorage");
+        if (feldsC != null) {
+            List<Instance> feldss = feldsC.getInstances();
+            if (feldss.size() != 1) {
+                throw new IllegalStateException("unexpected FlowExecutionList$DefaultStorage count: " + feldss);
+            }
+            fel = feldss.get(0);
+        } else {
+            JavaClass felC = heap.getJavaClassByName("org.jenkinsci.plugins.workflow.flow.FlowExecutionList");
+            List<Instance> fels = felC.getInstances();
+            if (fels.size() != 1) {
+                throw new IllegalStateException("unexpected FlowExecutionList count: " + fels);
+            }
+            fel = fels.get(0);
         }
-        Instance fel = fels.get(0);
+        if (fel == null) {
+            throw new IllegalStateException("FlowExecutionList custom storage not supported");
+        }
         Instance list = HeapWalker.valueOf(fel, "runningTasks.core"); // ArrayList
         ObjectArrayInstance elementsA = HeapWalker.valueOf(list, "elementData"); // TODO docs claim this would return Object[], but CONVERTERS does not actually do that
         List<Instance> elements = elementsA.getValues();

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -45,7 +45,7 @@ public class Main {
         Set<Build> listed = new TreeSet<>();
         for (int i = 0; i < size; i++) {
             System.err.print(".");
-            Build b = Build.of(elements.get(i));
+            Build b = Build.of(elements.get(i), fel);
             if (!listed.add(b)) {
                 System.err.print("(duplicated " + b + ")");
             }
@@ -61,7 +61,7 @@ public class Main {
             if (owner == null) {
                 continue; // running something else, fine
             }
-            Build b = Build.of(owner);
+            Build b = Build.of(owner, ooe);
             if (listed.contains(b)) {
                 continue; // actually running, fine
             }
@@ -77,7 +77,7 @@ public class Main {
         for (Instance ctg : heap.getJavaClassByName("org.jenkinsci.plugins.workflow.cps.CpsThreadGroup").getInstances()) {
             System.err.print(".");
             Instance owner = HeapWalker.valueOf(ctg, "execution.owner");
-            Build b = Build.of(owner);
+            Build b = Build.of(owner, ctg);
             Integer scriptSize = HeapWalker.valueOf(ctg, "scripts.size"); // TreeMap
             if (scriptSize == null) {
                 System.err.print("(possibly broken " + b + ")");
@@ -130,7 +130,7 @@ public class Main {
         Set<Build> leaked = new TreeSet<>();
         for (Instance cgstl : heap.getJavaClassByName("org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$TimingLoader").getInstances()) {
             System.err.print(".");
-            Build b = Build.of(HeapWalker.valueOf(cgstl, "execution.owner"));
+            Build b = Build.of(HeapWalker.valueOf(cgstl, "execution.owner"), cgstl);
             if (listed.contains(b)) {
                 continue; // actually running, fine
             }
@@ -144,24 +144,31 @@ public class Main {
         leaked.forEach(System.err::println);
     }
     static class Build implements Comparable<Build> {
-        static Build of(Instance owner) { // WorkflowRun$Owner
+        static Build of(Instance owner, Instance related) { // WorkflowRun$Owner
             Instance run = HeapWalker.valueOf(owner, "run");
-            return new Build(HeapWalker.valueOf(owner, "job"), Integer.parseInt(HeapWalker.valueOf(owner, "id")), run == null ? null : run.getInstanceId());
+            return new Build(
+                    HeapWalker.valueOf(owner, "job"),
+                    Integer.parseInt(HeapWalker.valueOf(owner, "id")),
+                    run == null ? null : run.getInstanceId(),
+                    related == null ? null : related.getInstanceId());
         }
         final String job;
         final int num;
         final Long id; // Heap address
-        Build(String job, int num, Long id) {
+        final Long relatedId; // Heap address of whatever object was used to find the WorkflowRun object
+        Build(String job, int num, Long id, Long relatedId) {
             this.job = job;
             this.num = num;
             this.id = id;
+            this.relatedId = relatedId;
         }
         @Override public int compareTo(Build o) {
             int c = job.compareTo(o.job);
             return c != 0 ? c : num - o.num;
         }
         @Override public String toString() {
-            return job + " #" + num + (id == null ? "" : "@" + id);
+            String relatedString = relatedId == null ? "" : " (via: 0x" + Long.toHexString(relatedId) + ")";
+            return job + " #" + num + (id == null ? "" : "@0x" + Long.toHexString(id)) + relatedString;
         }
         @Override public int hashCode() {
             return job.hashCode() ^ num;


### PR DESCRIPTION
* https://github.com/aragozin/jvm-tools/commit/0f9fcb920848423cb0103f2e015002adf0908a59 is needed for Java 10+ string support. It first landed in version 0.11 of `hprof-heap`, but the maintainer later split the library out into a separate repository, see https://github.com/aragozin/heaplib, so this PR swaps to the new artifact. I have been running this for years but forgot to file a PR for it.
* https://github.com/jenkinsci/workflow-api-plugin/pull/370 broke this script. I added support for `DefaultStorage` in this PR
* I added Hex-encoded output for easier use with tools like Eclipse MAT and started printing the address of the objects used to find the `WorkflowRun` to make things easier to link in cases where `CpsFlowExecution.cleanUpHeap` has already run

Known issues:
* I have run into https://github.com/aragozin/heaplib/issues/8 in the past (perhaps with dumps from newer JDKs, but I don't recall exactly). https://github.com/aragozin/heaplib/compare/master...dwnusbaum:heaplib:fasthprofheap-idtoinstancenumber-uoe seems to work fine to avoid the issue if you run into it. 
* Today I saw the following error with a Java 21 heap dump. Not sure about fixing it, going forward I will probably switch to just writing OQL scripts for MAT instead.
```
Exception in thread "main" org.netbeans.lib.profiler.heap.HeapOffsetMap$PageNotFoundEndOfHeapReachedExcpetion: No such ID, end of heap reached
	at org.netbeans.lib.profiler.heap.HeapOffsetMap.scanPage(HeapOffsetMap.java:208)
	at org.netbeans.lib.profiler.heap.HeapOffsetMap.offsetForCompressed(HeapOffsetMap.java:113)
	at org.netbeans.lib.profiler.heap.HeapOffsetMap.offset(HeapOffsetMap.java:79)
	at org.netbeans.lib.profiler.heap.FastHprofHeap.idToDumpOffset(FastHprofHeap.java:98)
	at org.netbeans.lib.profiler.heap.FastHprofHeap.getInstanceByID(FastHprofHeap.java:124)
	at org.netbeans.lib.profiler.heap.HprofInstanceObjectValue.getInstance(HprofInstanceObjectValue.java:37)
	at org.gridkit.jvmtool.heapdump.FieldStep.walk(FieldStep.java:44)
	at org.gridkit.jvmtool.heapdump.HeapWalker.collect(HeapWalker.java:508)
	at org.gridkit.jvmtool.heapdump.HeapWalker.valueOf(HeapWalker.java:222)
	at Main.main(Main.java:41)
```