### PR TITLE
Updates, supporting CBCI HA controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 Uses [this nifty library](https://github.com/aragozin/jvm-tools/tree/master/hprof-heap) to check for Jenkins heap dumps (`jmap -dump:live $pid`) containing “ghost” Pipeline builds.
+
+CloudBees CI HA controller? The list of registered running builds is not easily accessible from Hazelcast.
+Instead pass `jenkins-root-configuration-files/org.jenkinsci.plugins.workflow.flow.FlowExecutionList.xml` from a support bundle as a second argument.

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
     <build>
         <plugins>

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -96,6 +96,7 @@ public class Main {
         System.err.println();
         System.err.print("Looking for unlisted builds with program.dat loaded...");
         Map<Build, Instance> ctgs = new TreeMap<>();
+        int running = 0;
         for (Instance ctg : heap.getJavaClassByName("org.jenkinsci.plugins.workflow.cps.CpsThreadGroup").getInstances()) {
             System.err.print(".");
             Instance owner = HeapWalker.valueOf(ctg, "execution.owner");
@@ -108,6 +109,7 @@ public class Main {
             if (scriptSize == 0) {
                 continue; // completed, ignore
             }
+            running++;
             if (listed.contains(b.asListedBuild())) {
                 continue; // actually running, fine
             }
@@ -115,7 +117,7 @@ public class Main {
                 System.err.print("(duplicated " + b + ")");
             }
         }
-        System.err.println("found " + ctgs.size() + ".");
+        System.err.println("found " + ctgs.size() + " (compared to " + (running - ctgs.size()) + " legitimately running).");
         ctgs.forEach((b, ctg) -> {
             Instance owner = HeapWalker.valueOf(ctg, "execution.owner");
             System.err.println(b);

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -5,6 +5,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import org.gridkit.jvmtool.heapdump.HeapWalker;
 import org.netbeans.lib.profiler.heap.Heap;
 import org.netbeans.lib.profiler.heap.HeapFactory;
@@ -18,36 +23,53 @@ public class Main {
         System.err.print("Loading " + dump + "...");
         Heap heap = HeapFactory.createFastHeap(dump);
         System.err.println();
-        System.err.print("Looking for builds thought be running according to FlowExecutionList...");
-        Instance fel = null;
-        JavaClass feldsC = heap.getJavaClassByName("org.jenkinsci.plugins.workflow.flow.FlowExecutionList$DefaultStorage");
-        if (feldsC != null) {
-            List<Instance> feldss = feldsC.getInstances();
-            if (feldss.size() != 1) {
-                throw new IllegalStateException("unexpected FlowExecutionList$DefaultStorage count: " + feldss);
+        Set<ListedBuild> listed = new TreeSet<>();
+        if (args.length == 2) {
+            File felXml = new File(args[1]);
+            System.err.print("Loading " + felXml + "...");
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            Document doc = builder.parse(felXml);
+            NodeList flowOwners = doc.getElementsByTagName("flow-owner");
+            for (int i = 0; i < flowOwners.getLength(); i++) {
+                Element flowOwner = (Element) flowOwners.item(i);
+                String job = flowOwner.getElementsByTagName("job").item(0).getTextContent();
+                String id = flowOwner.getElementsByTagName("id").item(0).getTextContent();
+                listed.add(new ListedBuild(job, Integer.parseInt(id)));
             }
-            fel = feldss.get(0);
         } else {
-            JavaClass felC = heap.getJavaClassByName("org.jenkinsci.plugins.workflow.flow.FlowExecutionList");
-            List<Instance> fels = felC.getInstances();
-            if (fels.size() != 1) {
-                throw new IllegalStateException("unexpected FlowExecutionList count: " + fels);
+            System.err.print("Looking for builds thought be running according to FlowExecutionList...");
+            Instance fel = null;
+            JavaClass feldsC = heap.getJavaClassByName("org.jenkinsci.plugins.workflow.flow.FlowExecutionList$DefaultStorage");
+            if (feldsC != null) {
+                List<Instance> feldss = feldsC.getInstances();
+                if (feldss.size() != 1) {
+                    throw new IllegalStateException("unexpected FlowExecutionList$DefaultStorage count: " + feldss);
+                }
+                fel = feldss.get(0);
+            } else {
+                JavaClass felC = heap.getJavaClassByName("org.jenkinsci.plugins.workflow.flow.FlowExecutionList");
+                List<Instance> fels = felC.getInstances();
+                if (fels.size() != 1) {
+                    throw new IllegalStateException("unexpected FlowExecutionList count: " + fels);
+                }
+                fel = fels.get(0);
             }
-            fel = fels.get(0);
-        }
-        if (fel == null) {
-            throw new IllegalStateException("FlowExecutionList custom storage not supported");
-        }
-        Instance list = HeapWalker.valueOf(fel, "runningTasks.core"); // ArrayList
-        ObjectArrayInstance elementsA = HeapWalker.valueOf(list, "elementData"); // TODO docs claim this would return Object[], but CONVERTERS does not actually do that
-        List<Instance> elements = elementsA.getValues();
-        int size = HeapWalker.valueOf(list, "size");
-        Set<Build> listed = new TreeSet<>();
-        for (int i = 0; i < size; i++) {
-            System.err.print(".");
-            Build b = Build.of(elements.get(i), fel);
-            if (!listed.add(b)) {
-                System.err.print("(duplicated " + b + ")");
+            if (fel == null) {
+                throw new IllegalStateException("FlowExecutionList custom storage not supported");
+            }
+            Instance list = HeapWalker.valueOf(fel, "runningTasks.core"); // ArrayList
+            ObjectArrayInstance elementsA = HeapWalker.valueOf(list, "elementData"); // TODO docs claim this would return Object[], but CONVERTERS does not actually do that
+            if (elementsA == null) {
+                throw new IllegalStateException("FlowExecutionList default storage not initialized. CloudBees CI HA controller? Pass $JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.FlowExecutionList.xml as second argument.");
+            }
+            List<Instance> elements = elementsA.getValues();
+            int size = HeapWalker.valueOf(list, "size");
+            for (int i = 0; i < size; i++) {
+                System.err.print(".");
+                Build b = Build.of(elements.get(i), fel);
+                if (!listed.add(b.asListedBuild())) {
+                    System.err.print("(duplicated " + b + ")");
+                }
             }
         }
         System.err.println("found " + listed.size() + ".");
@@ -62,7 +84,7 @@ public class Main {
                 continue; // running something else, fine
             }
             Build b = Build.of(owner, ooe);
-            if (listed.contains(b)) {
+            if (listed.contains(b.asListedBuild())) {
                 continue; // actually running, fine
             }
             if (!executing.add(b)) {
@@ -86,7 +108,7 @@ public class Main {
             if (scriptSize == 0) {
                 continue; // completed, ignore
             }
-            if (listed.contains(b)) {
+            if (listed.contains(b.asListedBuild())) {
                 continue; // actually running, fine
             }
             if (ctgs.put(b, ctg) != null) {
@@ -104,13 +126,20 @@ public class Main {
             Instance pp = HeapWalker.valueOf(ctg, "execution.programPromise");
             System.err.println("  execution.programPromise: " + pp.getJavaClass().getName());
             Instance sync = HeapWalker.valueOf(pp, "sync");
-            Instance value = HeapWalker.valueOf(sync, "value");
-            if (value != null) {
-                System.err.println("    value: " + value.getJavaClass().getName());
-            }
-            Instance exception = HeapWalker.valueOf(sync, "exception");
-            if (exception != null) {
-                System.err.println("    exception: " + exception.getJavaClass().getName() + ": " + HeapWalker.valueOf(exception, "detailMessage"));
+            if (sync != null) {
+                Instance value = HeapWalker.valueOf(sync, "value");
+                if (value != null) {
+                    System.err.println("    value: " + value.getJavaClass().getName());
+                }
+                Instance exception = HeapWalker.valueOf(sync, "exception");
+                if (exception != null) {
+                    System.err.println("    exception: " + exception.getJavaClass().getName() + ": " + HeapWalker.valueOf(exception, "detailMessage"));
+                }
+            } else {
+                Instance value = HeapWalker.valueOf(pp, "value");
+                if (value != null) {
+                    System.err.println("    value: " + value.getJavaClass().getName());
+                }
             }
             Instance result = HeapWalker.valueOf(owner, "run.result");
             System.err.println("  result: " + (result != null ? HeapWalker.valueOf(result, "name") : null));
@@ -131,7 +160,7 @@ public class Main {
         for (Instance cgstl : heap.getJavaClassByName("org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$TimingLoader").getInstances()) {
             System.err.print(".");
             Build b = Build.of(HeapWalker.valueOf(cgstl, "execution.owner"), cgstl);
-            if (listed.contains(b)) {
+            if (listed.contains(b.asListedBuild())) {
                 continue; // actually running, fine
             }
             if (!leaked.add(b)) {
@@ -142,6 +171,15 @@ public class Main {
         }
         System.err.println("found " + leaked.size() + ".");
         leaked.forEach(System.err::println);
+    }
+    record ListedBuild(String job, int num) implements Comparable<ListedBuild> {
+        @Override public int compareTo(ListedBuild o) {
+            int c = job.compareTo(o.job);
+            return c != 0 ? c : num - o.num;
+        }
+        @Override public String toString() {
+            return job + " #" + num;
+        }
     }
     static class Build implements Comparable<Build> {
         static Build of(Instance owner, Instance related) { // WorkflowRun$Owner
@@ -161,6 +199,9 @@ public class Main {
             this.num = num;
             this.id = id;
             this.relatedId = relatedId;
+        }
+        ListedBuild asListedBuild() {
+            return new ListedBuild(job, num);
         }
         @Override public int compareTo(Build o) {
             int c = job.compareTo(o.job);

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -136,7 +136,7 @@ public class Main {
                     System.err.println("    exception: " + exception.getJavaClass().getName() + ": " + HeapWalker.valueOf(exception, "detailMessage"));
                 }
             } else {
-                Instance value = HeapWalker.valueOf(pp, "value");
+                Instance value = HeapWalker.valueOf(pp, "valueField");
                 if (value != null) {
                     System.err.println("    value: " + value.getJavaClass().getName());
                 }


### PR DESCRIPTION
https://github.com/jglick/dump-live-pipeline-programs/pull/2 tolerated an OSS API change but this allows the proprietary implementation to be parsed as well.

Note that for accuracy the FEL XML must be captured concurrently with the heap dump.